### PR TITLE
Rename to be-framework/skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
-# Be Framework Application Skeleton
+# Be Framework Skeleton
 
-Application skeleton for [Be Framework](https://be-framework.github.io/).
+Project skeleton for [Be Framework](https://be-framework.github.io/).
 
-## Installation
+## Getting Started
 
 ```bash
+composer create-project be-framework/skeleton MyProject
+cd MyProject
 composer install
 ```
 
 ## Usage
 
-Implement your application logic and run:
-
 ```bash
 php bin/app.php
 ```
+
+## Namespace
+
+Change `Be\Skeleton` to your own namespace using AI tools or find-and-replace.
+
+## Learn More
+
+- [Be Framework Documentation](https://be-framework.github.io/)

--- a/bin/app.php
+++ b/bin/app.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Be\App;
+namespace Be\Skeleton;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Be\App\Input\HelloInput;
-use Be\App\Module\AppModule;
+use Be\Skeleton\Input\HelloInput;
+use Be\Skeleton\Module\AppModule;
 use Be\Framework\Becoming;
 use Be\Framework\Exception\SemanticVariableException;
 use Ray\Di\Injector;

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "be-framework/app",
+    "name": "be-framework/skeleton",
     "type": "project",
     "autoload": {
         "psr-4": {
-            "Be\\App\\": "src/"
+            "Be\\Skeleton\\": "src/"
         }
     },
     "require": {

--- a/src/Exception/EmptyNameException.php
+++ b/src/Exception/EmptyNameException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\App\Exception;
+namespace Be\Skeleton\Exception;
 
 use Be\Framework\Attribute\Message;
 use DomainException;

--- a/src/Final/Hello.php
+++ b/src/Final/Hello.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Be\App\Final;
+namespace Be\Skeleton\Final;
 
-use Be\App\Reason\Greeting;
+use Be\Skeleton\Reason\Greeting;
 use Ray\Di\Di\Inject;
 use Ray\InputQuery\Attribute\Input;
 

--- a/src/Input/HelloInput.php
+++ b/src/Input/HelloInput.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Be\App\Input;
+namespace Be\Skeleton\Input;
 
-use Be\App\Final\Hello;
+use Be\Skeleton\Final\Hello;
 use Be\Framework\Attribute\Be;
 
 /** Input for Hello being　*/

--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Be\App\Module;
+namespace Be\Skeleton\Module;
 
-use Be\App\Reason\Greeting;
+use Be\Skeleton\Reason\Greeting;
 use Ray\Di\AbstractModule;
 
 final class AppModule extends AbstractModule

--- a/src/Reason/Greeting.php
+++ b/src/Reason/Greeting.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Be\App\Reason;
+namespace Be\Skeleton\Reason;
 
 final class Greeting
 {

--- a/src/Semantic/Name.php
+++ b/src/Semantic/Name.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Be\App\Semantic;
+namespace Be\Skeleton\Semantic;
 
 use Be\Framework\Attribute\Validate;
-use Be\App\Exception\EmptyNameException;
-use Be\App\Exception\InvalidNameFormatException;
-use Be\App\Tag\English;
+use Be\Skeleton\Exception\EmptyNameException;
+use Be\Skeleton\Exception\InvalidNameFormatException;
+use Be\Skeleton\Tag\English;
 use function preg_match;
 use function trim;
 


### PR DESCRIPTION
## Summary
- Rename package from `be-framework/app` to `be-framework/skeleton`
- Rename namespace from `Be\App` to `Be\Skeleton`
- Update README for skeleton project

## Note
After merge, rename the GitHub repository from `app` to `skeleton` in Settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with a streamlined composer-based project setup workflow.
  * Added comprehensive section on customizing the project namespace configuration for your specific application needs.
  * Simplified core usage instructions and included direct links to framework documentation for further learning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->