### PR TITLE
Add default Being semantic to suppress framework notice

### DIFF
--- a/src/Semantic/Being.php
+++ b/src/Semantic/Being.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Skeleton\Semantic;
+
+use Be\Framework\Attribute\Validate;
+
+/**
+ * Being
+ *
+ * `$being` is a Be Framework convention used for type-matching in branching
+ * metamorphosis. It is not an app-specific semantic variable, but the framework
+ * still looks up a semantic validator for it in the app's Semantic namespace.
+ *
+ * This default no-op validator exists to suppress the framework notice:
+ *   "Semantic variable 'Being' not registered in ontology namespace".
+ *
+ * You may edit this class to add constraints on what types can be assigned to
+ * `$being` (for example, restricting it to a specific set of class names).
+ */
+final class Being
+{
+    #[Validate]
+    public function validate(string $being): void
+    {
+        // No-op by default. Add constraints here if needed.
+    }
+}


### PR DESCRIPTION
## Problem

When a Be Framework app has a Being class with a `$being` property (used for type-matching in branching metamorphosis), the framework looks up a semantic validator for `being` in the app's Semantic namespace. If no `Semantic/Being.php` exists, the framework emits a notice:

> Semantic variable 'Being' not registered in ontology namespace

`$being` is a framework convention for type-matching, not an app-specific semantic variable, so every skeleton-based app would hit this notice by default.

## Solution

Add a default no-op `src/Semantic/Being.php` so:

1. The notice is suppressed out of the box.
2. App authors can edit the class to add constraints (for example, restricting `$being` to a specific set of class names) if they want to.

The class follows the same pattern as `src/Semantic/Name.php` but with an empty `#[Validate]` method and a docblock explaining its purpose.

## Test

- [x] `./vendor/bin/phpunit --no-coverage` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented built-in semantic validation support to automatically handle framework conventions without requiring explicit configuration.

* **Bug Fixes**
  * Resolved notices appearing during semantic validation when validators weren't explicitly registered, providing a seamless validation experience across framework conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->