### PR TITLE
Configure phpunit coverage source filter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,4 +8,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary
- Add `<source>` element to `phpunit.xml` pointing at `src/` so `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text` produces a coverage report out of the box.
- Eliminates the "No filter is configured, code coverage will not be processed" warning.
- Follow-up to #7 — that work intentionally left `src/` free of sample `.php` stubs, so coverage starts clean rather than noisy.

## Test plan
- [x] `composer install`
- [x] `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text` reports coverage for `Hello`, `HelloInput`, `AppModule`, `Name`, etc. and no longer warns.
- [x] `vendor/bin/phpunit` (no flag) still green (1 test, 2 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved testing infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->