### PR TITLE
Add directory layout section to README (EN/JA)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,55 @@
+# Be Framework スケルトン
+
+[Be Framework](https://be-framework.github.io/) のプロジェクトスケルトン。
+
+## はじめに
+
+```bash
+composer create-project be-framework/skeleton MyProject
+cd MyProject
+```
+
+## 使い方
+
+```bash
+composer dev      # セマンティックログ付きで実行 → var/log/<timestamp>.json
+composer stree    # 最新ログをツリー表示
+composer app      # 本番モードで実行（ログなし）
+
+# 直接呼び出し（BEAR.Sunday スタイルの URI）
+php bin/app.php 'hello?name=Alice'
+MODULE=app php bin/app.php 'order?customerId=42&items[]=P1001'
+```
+
+開発ループ、`MODULE` 環境変数、URI 呼び出し規約は `CLAUDE.md` を参照。
+
+## ディレクトリ構成
+
+スケルトンには `src/<dir>/` が10個ありますが、3つは必要になるまで意図的に空にしてあります。各行は [Be Framework マニュアル](https://be-framework.github.io/manuals/1.0/ja/) の対応する章にリンクしています。
+
+| dir | 役割 | マニュアル |
+|---|---|---|
+| `src/Input/`      | パイプラインの起点。`#[Be([Target::class])]` で次段を宣言。                                | [Input クラス](https://be-framework.github.io/manuals/1.0/ja/02-input-classes.html) |
+| `src/Final/`      | 終点。`#[Input]` でデータ、`#[Inject]` でサービスを受け取る。                              | [Final オブジェクト](https://be-framework.github.io/manuals/1.0/ja/04-final-objects.html) |
+| `src/Semantic/`   | セマンティック変数（バリデータ）。クラス名 = パラメータ名（camelCase）。                       | [セマンティック変数](https://be-framework.github.io/manuals/1.0/ja/06-semantic-variables.html) |
+| `src/Exception/`  | セマンティック検証例外。`#[Message]` で多言語化。                                             | [エラーハンドリング](https://be-framework.github.io/manuals/1.0/ja/09-error-handling.html) |
+| `src/Reason/`     | 「存在を可能にするもの」— Entity、Media（Command/Query）、ポリシー、ガード。                  | [Reason レイヤー](https://be-framework.github.io/manuals/1.0/ja/08-reason-layer.html) |
+| `src/Module/`     | Ray.Di モジュール。`MODULE=<name>` で有効モジュールを切り替え。                                | （スケルトン固有 — `CLAUDE.md` 参照） |
+| `src/Becoming/`   | フレームワーク配線層。ユーザーコードを置く場所ではない。                                       | [Becoming](https://be-framework.github.io/manuals/1.0/ja/04a-becoming.html) |
+| `src/Being/`      | *(空)* `$being` 判別子 + `#[Be([FinalA, ...])]` を使う Branching 中間形。                     | [Being クラス](https://be-framework.github.io/manuals/1.0/ja/03-being-classes.html) |
+| `src/LogContext/` | *(空)* `Been` に添えるセマンティックログのイベントクラス。                                     | [セマンティックロギング](https://be-framework.github.io/manuals/1.0/ja/10-semantic-logging.html) |
+| `src/Moment/`     | *(空)* Diamond の部分 — `MomentInterface` を実装し、`be()` で潜在性を実現。                   | [メタモルフォーシスパターン](https://be-framework.github.io/manuals/1.0/ja/05-metamorphosis-patterns.html) |
+
+## 名前空間
+
+`Be\Skeleton` は AI ツールまたは find-and-replace で自分のプロジェクトの名前空間に置き換えてください。
+
+## もっと知る
+
+- [Be Framework ドキュメント](https://be-framework.github.io/)
+- [be-skills](https://github.com/be-framework/be-skills) — Be Framework アプリを end-to-end で作るための Claude Code スキル（プロジェクト設定、設計ワークフロー、開発ループ、デバッグ）。
+- [be-patterns](https://github.com/be-framework/be-patterns) — 8つの実行可能なパターンデモ（Linear、Diamond、Branching、Cascade Diamond、Complex Convergence、…）。
+
+---
+
+[English version](./README.md)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ MODULE=app php bin/app.php 'order?customerId=42&items[]=P1001'
 
 See `CLAUDE.md` for the dev loop, `MODULE` env var, and the URI invocation convention.
 
+## Directory layout
+
+The skeleton ships ten `src/<dir>/` slots — three are intentionally empty until you need them. Each row links to the matching chapter of the [Be Framework manual](https://be-framework.github.io/manuals/1.0/en/).
+
+| dir | role | manual |
+|---|---|---|
+| `src/Input/`      | Pipeline entry. Declares `#[Be([Target::class])]`.                                  | [Input Classes](https://be-framework.github.io/manuals/1.0/en/02-input-classes.html) |
+| `src/Final/`      | Terminus. Receives `#[Input]` data + `#[Inject]` services.                          | [Final Objects](https://be-framework.github.io/manuals/1.0/en/04-final-objects.html) |
+| `src/Semantic/`   | Semantic variables (validators). Class name = parameter name (camelCase).           | [Semantic Variables](https://be-framework.github.io/manuals/1.0/en/06-semantic-variables.html) |
+| `src/Exception/`  | Semantic-validation exceptions with `#[Message]` for i18n.                          | [Error Handling](https://be-framework.github.io/manuals/1.0/en/09-error-handling.html) |
+| `src/Reason/`     | "What makes existence possible" — Entity, Media (Command/Query), policies, guards.  | [Reason Layer](https://be-framework.github.io/manuals/1.0/en/08-reason-layer.html) |
+| `src/Module/`     | Ray.Di modules. `MODULE=<name>` env switches the active module.                     | (skeleton-specific — see `CLAUDE.md`) |
+| `src/Becoming/`   | Framework wiring layer. Not user code.                                              | [Becoming](https://be-framework.github.io/manuals/1.0/en/04a-becoming.html) |
+| `src/Being/`      | *(empty)* Branching intermediate with `$being` discriminator + `#[Be([FinalA, ...])]`. | [Being Classes](https://be-framework.github.io/manuals/1.0/en/03-being-classes.html) |
+| `src/LogContext/` | *(empty)* Semantic-log event classes attached to `Been`.                            | [Semantic Logging](https://be-framework.github.io/manuals/1.0/en/10-semantic-logging.html) |
+| `src/Moment/`     | *(empty)* Diamond parts — `implements MomentInterface`, `be()` realizes potential.  | [Metamorphosis Patterns](https://be-framework.github.io/manuals/1.0/en/05-metamorphosis-patterns.html) |
+
 ## Namespace
 
 Change `Be\Skeleton` to your own namespace using AI tools or find-and-replace.
@@ -32,3 +49,7 @@ Change `Be\Skeleton` to your own namespace using AI tools or find-and-replace.
 - [Be Framework Documentation](https://be-framework.github.io/)
 - [be-skills](https://github.com/be-framework/be-skills) — Claude Code skills for building Be Framework apps end-to-end (project setup, design workflow, dev loop, debugging).
 - [be-patterns](https://github.com/be-framework/be-patterns) — eight runnable pattern demos (Linear, Diamond, Branching, Cascade Diamond, Complex Convergence, …).
+
+---
+
+[日本語版はこちら](./README.ja.md)


### PR DESCRIPTION
## Summary

Adds a **Directory layout** table to `README.md` mapping each `src/<dir>/` to its role and the matching chapter of the [Be Framework manual](https://be-framework.github.io/manuals/1.0/en/), and ships a Japanese mirror as `README.ja.md` (links pointing to the JA manual).

Closes the in-tree discoverability gap raised in #7 — newcomers no longer have to guess what the empty `Being/`, `LogContext/`, `Moment/` dirs are for.

## Scope decision (vs original #7 proposal)

#7 originally proposed per-dir `README.md` (×9–10) + reference PHP examples (`ExampleBeing`, `ExampleContext`, `ExampleMoment`) + a `composer post-create-project-cmd` to gitignore the READMEs from end-user projects.

After discussion the scope collapsed to a single top-level table because:

1. Sample `.php` files in `src/` get scanned by static analysis and coverage tools, forcing them to be either fully wired or explicitly excluded — net cost > value for a skeleton.
2. Once samples move out, per-dir READMEs reduce to "role + manual link" — that's exactly what the table at the top expresses, with no ×10 duplication.
3. The Be Framework manual already has comprehensive per-topic chapters in both EN and JA, so the skeleton's job is to point at them, not re-explain.
4. `README.md` + `README.ja.md` mirrors the i18n convention already used in [be-patterns](https://github.com/be-framework/be-patterns).

Net effect: no `composer.json` changes, no gitignore strategy, no PHP example files, no per-dir doc files — just two top-level READMEs.

## Test plan

- [x] `composer dev` — Hello pipeline runs, `var/log/<timestamp>.json` written
- [x] `composer stree` — latest log renders
- [x] `vendor/bin/phpunit` — 1 test, 2 assertions, green
- [x] `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text --coverage-filter=src` — coverage reports on the existing `src/` classes only; empty dirs (`.gitkeep` only) and the new docs are invisible to coverage as intended
- [ ] Visual: spot-check 2 EN + 2 JA manual links resolve in browser
- [ ] (Reviewer) confirm `*(empty)*` annotation reads naturally for the three empty-by-default dirs

Refs #7