### PR TITLE
Link to Directory Layout manual from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ Change `Be\Skeleton` to your own namespace using AI tools or find-and-replace.
 ## Learn More
 
 - [Be Framework Documentation](https://be-framework.github.io/)
+- [Directory Layout](https://be-framework.github.io/manuals/1.0/en/convention/directory-layout.html) — what each `src/<dir>/` slot is for.
 - [be-skills](https://github.com/be-framework/be-skills) — Claude Code skills for building Be Framework apps end-to-end (project setup, design workflow, dev loop, debugging).
 - [be-patterns](https://github.com/be-framework/be-patterns) — eight runnable pattern demos (Linear, Diamond, Branching, Cascade Diamond, Complex Convergence, …).


### PR DESCRIPTION
## Summary

Adds a single link to the new Directory Layout convention page under the README's **Learn More** section, so skeleton visitors can jump to the canonical "where does what go" reference.

Link target: [be-framework.github.io#24](https://github.com/be-framework/be-framework.github.io/pull/24).

## Motivation

Closes [#7](https://github.com/be-framework/skeleton/issues/7). The issue originally proposed per-directory READMEs inside the skeleton; the manual's convention page covers the same ground in one canonical, i18n-ready location, so the skeleton itself stays minimal.

## Test plan

- [ ] GitHub renders the new link under Learn More.
- [ ] The Directory Layout link resolves (once be-framework.github.io#24 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)