### PR TITLE
Use Be\App as the default app namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Project-specific guidance for Claude Code in this repository.
 
 ## Project
 
-Skeleton for [Be Framework](https://be-framework.github.io/) applications. Namespace `Be\Skeleton\` is intended to be replaced with the app's own namespace.
+Template for [Be Framework](https://be-framework.github.io/) applications. Namespace `Be\App\` is the app namespace used by the generated project.
 
 For Be Framework methodology (project setup, design workflow, patterns, debugging) see the [`be-skills`](https://github.com/be-framework/be-skills) Claude Code plugin (`be` and `be-semantic` skills). This file covers only what is specific to **this** skeleton.
 
@@ -16,7 +16,7 @@ composer profile                # semantic profiling — writes var/log/<timesta
 composer stree                  # render the latest log as a semantic tree
 composer stree:full             # semantic full tree with full props and close.profile details
 
-# Direct invocation: bin/be.php takes one BEAR.Sunday-style URI argument
+# Direct invocation: `bin/be.php` takes one BEAR.Sunday-style URI argument
 #   <input>?<key>=<value>&...
 php bin/be.php                                          # default → 'hello?name=World'
 php bin/be.php 'hello?name=Alice'
@@ -27,11 +27,11 @@ vendor/bin/phpunit
 
 ## Skeleton-specific wiring
 
-- **`bin/be.php`** — single universal entry. Parses the CLI argument with `parse_url` + `parse_str`, maps the path to `Be\Skeleton\Input\<Ucfirst>Input` and spreads the query as named constructor args. Module is resolved via the `MODULE` env var (default `dev`) → `Be\Skeleton\Module\<Ucfirst>Module`. The same URI shape mirrors what a future `be://` scheme could route from BEAR.Sunday.
+- **`bin/be.php`** — single universal entry. Parses the CLI argument with `parse_url` + `parse_str`, maps the path to `Be\App\Input\<Ucfirst>Input` and spreads the query as named constructor args. Module is resolved via the `MODULE` env var (default `dev`) → `Be\App\Module\<Ucfirst>Module`. The same URI shape mirrors what a future `be://` scheme could route from BEAR.Sunday.
 - **`src/Module/DevModule.php`** — installs `AppModule` then rebinds `BecomingInterface` to `DevBecoming`. Adding a new mode is a matter of dropping `XxxModule` into `src/Module/` and invoking with `MODULE=xxx`.
 - **`src/Becoming/DevBecoming.php`** — wraps `Becoming` and writes a semantic log to `var/log/<timestamp>.json` from a `finally` block, so failed pipelines are captured too (consumed by `composer stree`).
 - **`var/log/*`** is git-ignored except `.gitkeep`; `stree` reads the newest JSON there.
 
 ## Tests
 
-Tests construct `Injector(new AppModule())` then `getInstance(Becoming::class)` (or build `new Becoming($injector, 'Be\Skeleton\Semantic')` directly when minimal wiring is the point). Don't mock the framework — swap modules instead, the way `DevModule` does for the dev loop.
+Tests construct `Injector(new AppModule())` then `getInstance(Becoming::class)` (or build `new Becoming($injector, 'Be\App\Semantic')` directly when minimal wiring is the point). Don't mock the framework — swap modules instead, the way `DevModule` does for the dev loop.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run `composer dev` or `composer profile` before `composer stree` if you need a f
 
 ## Namespace
 
-The generated app uses the `Be\App` namespace. The package name stays `be-framework/skeleton`.
+The generated app uses the `Be\App` namespace by default. You can rename it to your own namespace with AI tools or find-and-replace.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Be Framework Skeleton
+# Be Framework App
 
-Project skeleton for [Be Framework](https://be-framework.github.io/).
+Project template for [Be Framework](https://be-framework.github.io/).
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ Run `composer dev` or `composer profile` before `composer stree` if you need a f
 
 ## Namespace
 
-Change `Be\Skeleton` to your own namespace using AI tools or find-and-replace.
+The generated app uses the `Be\App` namespace. The package name stays `be-framework/skeleton`.
 
 ## Learn More
 

--- a/bin/be.php
+++ b/bin/be.php
@@ -4,11 +4,11 @@
  * Universal entry point for a Be Framework app.
  *
  * Invocation mirrors a URI: `<input>?<query>` where:
- *   - `<input>` is mapped to `Be\Skeleton\Input\<Ucfirst>Input`
+ *   - `<input>` is mapped to `Be\App\Input\<Ucfirst>Input`
  *   - `<query>` is parsed by `parse_str()` and spread as named constructor args
  *
  * The Module is selected by the `MODULE` environment variable
- * (`Be\Skeleton\Module\<Ucfirst>Module`); defaults to `dev`.
+ * (`Be\App\Module\<Ucfirst>Module`); defaults to `dev`.
  *
  * Examples:
  *   php bin/be.php                                    # default → 'hello?name=World'
@@ -22,7 +22,7 @@
  * (int / float / bool) under PHP's standard coercion rules.
  */
 
-namespace Be\Skeleton;
+namespace Be\App;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-            "Be\\Skeleton\\": "src/"
+            "Be\\App\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Be\\Skeleton\\": "tests/"
+            "Be\\App\\": "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "be-framework/be": "0.x-dev as 0.1.0",
-        "koriym/semantic-logger": "^0.7",
+        "koriym/semantic-logger": "^0.8",
         "ray/di": "^2.18"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62f79ad92dd84659c70aa2e291ef4bcc",
+    "content-hash": "b68e352f0a7a2f1b65a9a661e45796ee",
     "packages": [
         {
             "name": "be-framework/be",
@@ -12,16 +12,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/koriym/be-framework.git",
-                "reference": "c2073bfbe043fdeeae7e5620af7d4731e2ad43d9"
+                "reference": "6f473181f95d258bb55d655a10e74d034d4f57ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koriym/be-framework/zipball/c2073bfbe043fdeeae7e5620af7d4731e2ad43d9",
-                "reference": "c2073bfbe043fdeeae7e5620af7d4731e2ad43d9",
+                "url": "https://api.github.com/repos/koriym/be-framework/zipball/6f473181f95d258bb55d655a10e74d034d4f57ea",
+                "reference": "6f473181f95d258bb55d655a10e74d034d4f57ea",
                 "shasum": ""
             },
             "require": {
-                "koriym/semantic-logger": "^0.7",
+                "koriym/semantic-logger": "^0.8",
                 "php": "^8.3",
                 "ray/di": "^2.18",
                 "ray/input-query": "^v1.0"
@@ -62,7 +62,7 @@
                 "issues": "https://github.com/koriym/be-framework/issues",
                 "source": "https://github.com/koriym/be-framework/tree/0.x"
             },
-            "time": "2026-04-22T17:50:33+00:00"
+            "time": "2026-04-24T11:31:53+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -195,16 +195,16 @@
         },
         {
             "name": "koriym/semantic-logger",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/koriym/Koriym.SemanticLogger.git",
-                "reference": "be13b159482159d1c79c3a5ff1942d443dfe3d37"
+                "reference": "11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koriym/Koriym.SemanticLogger/zipball/be13b159482159d1c79c3a5ff1942d443dfe3d37",
-                "reference": "be13b159482159d1c79c3a5ff1942d443dfe3d37",
+                "url": "https://api.github.com/repos/koriym/Koriym.SemanticLogger/zipball/11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d",
+                "reference": "11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d",
                 "shasum": ""
             },
             "require": {
@@ -244,9 +244,9 @@
             "description": "Type-safe structured logging with schema validation and meaningful context",
             "support": {
                 "issues": "https://github.com/koriym/Koriym.SemanticLogger/issues",
-                "source": "https://github.com/koriym/Koriym.SemanticLogger/tree/0.7.0"
+                "source": "https://github.com/koriym/Koriym.SemanticLogger/tree/0.8.0"
             },
-            "time": "2026-04-22T03:00:33+00:00"
+            "time": "2026-04-24T08:34:32+00:00"
         },
         {
             "name": "marc-mabe/php-enum",

--- a/src/Becoming/DevBecoming.php
+++ b/src/Becoming/DevBecoming.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Becoming;
+namespace Be\App\Becoming;
 
 use Be\Framework\Becoming;
 use Be\Framework\BecomingInterface;

--- a/src/Exception/EmptyNameException.php
+++ b/src/Exception/EmptyNameException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Exception;
+namespace Be\App\Exception;
 
 use Be\Framework\Attribute\Message;
 use DomainException;

--- a/src/Final/Hello.php
+++ b/src/Final/Hello.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Final;
+namespace Be\App\Final;
 
-use Be\Skeleton\Reason\Greeting;
+use Be\App\Reason\Greeting;
 use Ray\Di\Di\Inject;
 use Ray\InputQuery\Attribute\Input;
 

--- a/src/Input/HelloInput.php
+++ b/src/Input/HelloInput.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Input;
+namespace Be\App\Input;
 
-use Be\Skeleton\Final\Hello;
+use Be\App\Final\Hello;
 use Be\Framework\Attribute\Be;
 
 /** Input for Hello */

--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Module;
+namespace Be\App\Module;
 
 use Be\Framework\Module\BeModule;
-use Be\Skeleton\Reason\Greeting;
+use Be\App\Reason\Greeting;
 use Ray\Di\AbstractModule;
 
 final class AppModule extends AbstractModule
 {
     protected function configure(): void
     {
-        $this->install(new BeModule('Be\\Skeleton\\Semantic'));
+        $this->install(new BeModule('Be\\App\\Semantic'));
         $this->bind(Greeting::class);
     }
 }

--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Be\App\Module;
 
-use Be\Framework\Module\BeModule;
 use Be\App\Reason\Greeting;
+use Be\Framework\Module\BeModule;
 use Ray\Di\AbstractModule;
 
 final class AppModule extends AbstractModule

--- a/src/Module/DevModule.php
+++ b/src/Module/DevModule.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Be\App\Module;
 
+use Be\App\Becoming\DevBecoming;
 use Be\Framework\Becoming;
 use Be\Framework\BecomingInterface;
-use Be\App\Becoming\DevBecoming;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;

--- a/src/Module/DevModule.php
+++ b/src/Module/DevModule.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Module;
+namespace Be\App\Module;
 
 use Be\Framework\Becoming;
 use Be\Framework\BecomingInterface;
-use Be\Skeleton\Becoming\DevBecoming;
+use Be\App\Becoming\DevBecoming;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;

--- a/src/Module/DevSemanticLoggerProvider.php
+++ b/src/Module/DevSemanticLoggerProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Module;
+namespace Be\App\Module;
 
 use Koriym\SemanticLogger\DevSemanticLogger;
 use Koriym\SemanticLogger\SemanticLogger;

--- a/src/Reason/Greeting.php
+++ b/src/Reason/Greeting.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Reason;
+namespace Be\App\Reason;
 
 final class Greeting
 {

--- a/src/Semantic/Being.php
+++ b/src/Semantic/Being.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Semantic;
+namespace Be\App\Semantic;
 
 use Be\Framework\Attribute\Validate;
 
@@ -22,7 +22,7 @@ use Be\Framework\Attribute\Validate;
 final class Being
 {
     #[Validate]
-    public function validate(string $being): void
+    public function validate(mixed $being): void
     {
         // No-op by default. Add constraints here if needed.
     }

--- a/src/Semantic/Name.php
+++ b/src/Semantic/Name.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Be\App\Semantic;
 
-use Be\Framework\Attribute\Validate;
 use Be\App\Exception\EmptyNameException;
+use Be\Framework\Attribute\Validate;
+
 use function trim;
 
 /**

--- a/src/Semantic/Name.php
+++ b/src/Semantic/Name.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton\Semantic;
+namespace Be\App\Semantic;
 
 use Be\Framework\Attribute\Validate;
-use Be\Skeleton\Exception\EmptyNameException;
+use Be\App\Exception\EmptyNameException;
 use function trim;
 
 /**

--- a/tests/HelloTest.php
+++ b/tests/HelloTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Be\App;
 
+use Be\App\Final\Hello;
 use Be\App\Input\HelloInput;
 use Be\App\Module\AppModule;
-use Be\App\Final\Hello;
 use Be\Framework\Becoming;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;

--- a/tests/HelloTest.php
+++ b/tests/HelloTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Be\Skeleton;
+namespace Be\App;
 
-use Be\Skeleton\Input\HelloInput;
-use Be\Skeleton\Module\AppModule;
-use Be\Skeleton\Final\Hello;
+use Be\App\Input\HelloInput;
+use Be\App\Module\AppModule;
+use Be\App\Final\Hello;
 use Be\Framework\Becoming;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -16,7 +16,7 @@ class HelloTest extends TestCase
     public function testHello(): void
     {
         $injector = new Injector(new AppModule());
-        $becoming = new Becoming($injector, 'Be\Skeleton\Semantic');
+        $becoming = new Becoming($injector, 'Be\App\Semantic');
         $input = new HelloInput('World');
         $hello = $becoming($input);
         $this->assertInstanceOf(Hello::class, $hello);


### PR DESCRIPTION
## Summary
- keep the template identity as `be-skeleton` / `be-framework/skeleton`
- switch the generated app namespace back from `Be\Skeleton` to `Be\App`
- widen the default `Semantic\Being` validator to accept the object-based `$being` used in branching tutorials

## Context
PR #1 renamed both the template identity and the generated app namespace to `Skeleton`.
After walking through Getting Started and the tutorial flow, it became clear that the generated application reads more naturally with `Be\App`, while the template itself should still remain `be-skeleton`.

This PR keeps the template/package naming introduced by PR #1, but separates it from the default namespace used by the generated app.

## Verification
- `composer dump-autoload`
- `vendor/bin/phpunit`
- `composer dev`
- `composer stree`
- `composer stree:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance and examples to reflect the app's standardized namespace naming.

* **Refactor**
  * Unified application namespace throughout the codebase for consistency.

* **Chores**
  * Upgraded semantic logger dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->