### PR TITLE
Use explicit 0.x-dev in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Project template for [Be Framework](https://be-framework.github.io/).
 ## Getting Started
 
 ```bash
-composer create-project be-framework/skeleton MyProject --stability dev
+composer create-project be-framework/skeleton:0.x-dev MyProject
 cd MyProject
 ```
 


### PR DESCRIPTION
## Summary

- Change install command from `--stability dev` to `:0.x-dev` to avoid picking up stale `1.x-dev` metadata still served by Packagist.

## Test plan

- [ ] `composer create-project be-framework/skeleton:0.x-dev my-project` installs the current `0.x` branch (a7ffd6d).
- [ ] `cd my-project && composer dev` runs and writes to `var/log/<timestamp>.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Getting Started" setup instructions with clarified dependency version specification for improved installation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->