### PR TITLE
Use Psalm 7 dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0",
-        "vimeo/psalm": "^6.16",
+        "vimeo/psalm": "7.x-dev@dev",
         "be-framework/psalm-plugin": "1.x-dev"
     },
     "scripts": {


### PR DESCRIPTION
## Summary
- Switch the skeleton Psalm dev dependency from `^6.16` to `7.x-dev@dev`.

## Notes
- This is intentionally a draft because `be-framework/psalm-plugin` currently requires `vimeo/psalm ^6.0@dev`, so dependency resolution does not yet succeed with Psalm 7.

## Verification
- `composer validate --no-check-publish` exits 0.
- `vendor/bin/phpunit` passes with the current local vendor tree.
- `composer dev` passes with the current local vendor tree.
- `composer update --no-interaction` currently fails due to the `be-framework/psalm-plugin` Psalm 6 constraint.
- `composer psalm` currently fails because the plugin cannot be installed under the unresolved dependency set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to their latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->